### PR TITLE
Fixed undefined variable - closes #13

### DIFF
--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -100,7 +100,7 @@ Messenger.prototype.stopScanning = function(callback) {
 Messenger.prototype.connect = function(address, addressType, callback) {
   // params: address, address_type, conn_interval_min, conn_interval_max, timeout, latency
   // TODO: Make last four params configurable?
-  this.execute(bglib.api.gapConnectDirect, [address, address_type, 1000, 2000, 3200, 0], callback);
+  this.execute(bglib.api.gapConnectDirect, [address, addressType, 1000, 2000, 3200, 0], callback);
 }
 Messenger.prototype.disconnect = function(connection, callback) {
   // params: address, address_type, conn_interval_min, conn_interval_max, timeout, latency


### PR DESCRIPTION
By passing an undefined variable into bglib, the command packet builder was passing an undefined Buffer into Buffer.concat() which got treated as a <Buffer 00 >. This is coincidentally the correct value for addressType when connecting to a device with a public address, however iOS devices and the FitBit Flex use a random address, which requires a value of 1, rather than 0, in that parameter. This change ensures that the correct value is propagated down to bglib when the packet is created.

@johnnyman727 
